### PR TITLE
Update site color in Jekyll config for ESE 2017

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ baseurl: "/2017" # the subpath of your site, e.g. /blog/
 url: "https://ese.ifsr.de" # the base hostname & protocol for your site
 twitter_username: ifsr
 github_username:  fsr
-color: "#FDC412"
+color: "#0D5F98"
 year: "2017"
 
 # Global Metatags


### PR DESCRIPTION
The site color in the Jekyll config is still the old color from ESE 2016. Among other things, it's used as theme color on Android. The old yellow doesn't look well together with the new blue theme. Update it to color for ESE 2017 (`#0D5F98`).

| ![screenshot_20170930-191054](https://user-images.githubusercontent.com/3035868/31047955-36c1af6e-a614-11e7-9967-115fa0638eca.png) | ![screenshot_20170930-191426](https://user-images.githubusercontent.com/3035868/31047956-36d89986-a614-11e7-94f4-de4a6a9121a2.png)  |
| ------------- | ------------- |
