### PR TITLE
Exercise Diplom/1 on Fri 1st lesson room change

### DIFF
--- a/sources/_data/schedules.yml
+++ b/sources/_data/schedules.yml
@@ -491,7 +491,7 @@ values:
         title: TGI
         type: Ü
         slot: 1
-        location: GER/0054
+        location: HSZ/0201
   -
     name: Diplom/2
     Montag:


### PR DESCRIPTION
The exercise of the Diplom/1-scheudle on friday in TGI in room GER/0054 has been moved to room HSZ/0201. Diplom/1 and 2 have this exercise together.